### PR TITLE
Fix plural

### DIFF
--- a/web/massastation/src/i18n/en_US.json
+++ b/web/massastation/src/i18n/en_US.json
@@ -4,7 +4,7 @@
     "mystation-banner": "My Station",
     "mystation": {
       "loading": "Loading...",
-      "browse": "Browse the store below and manage plugin you've installed in this section"
+      "browse": "Browse the store below and manage plugins you've installed in this section"
     }
   }
 }


### PR DESCRIPTION
BEFORE 

 "browse": "Browse the store below and manage plugin you've installed in this section"

AFTER
 "browse": "Browse the store below and manage plugins you've installed in this section"