### PR TITLE
fix dashboard

### DIFF
--- a/web/massastation/src/pages/Index/Index.tsx
+++ b/web/massastation/src/pages/Index/Index.tsx
@@ -31,6 +31,7 @@ export function Index() {
   const [pluginWalletIsInstalled, setPluginWalletIsInstalled] = useState(false);
   const [urlPlugin, setUrlPlugin] = useState('');
   const [theme]: string = useOutletContext();
+  const [refreshPlugins, setRefreshPlugins] = useState(0);
 
   const { data: plugins } = useResource<PluginHomePage[]>('plugin-manager');
 
@@ -48,7 +49,7 @@ export function Index() {
     setPluginWalletIsInstalled(Boolean(isWalletInstalled));
     if (!isWalletInstalled && availablePlugins) {
       const walletPlugin = availablePlugins.find(
-        (plugin: PluginStoreItemRequest) => plugin.name === 'Massa Wallet',
+        (plugin: PluginStoreItemRequest) => plugin.name === 'MassaWallet',
       );
       if (walletPlugin) {
         setUrlPlugin(walletPlugin.file.url);
@@ -64,6 +65,10 @@ export function Index() {
       setPluginWalletIsInstalled(false);
     }
   }, [isSuccess, isError]);
+
+  useEffect(() => {
+    setRefreshPlugins(refreshPlugins + 1);
+  }, [pluginWalletIsInstalled]);
 
   function handleInstallPlugin() {
     try {
@@ -101,6 +106,7 @@ export function Index() {
               </Button>
             </div>
             <DashboardStation
+              key={refreshPlugins}
               theme={theme}
               imagesDark={[
                 <Image1Dark />,


### PR DESCRIPTION
It's a temporary fix:
When the Index page is displayed, we display the Dashboard components with PluginWallet. The dashboard is a parent component of PluginWallet. So when there's a change to the "pluginWalletIsInstalled" variable, the Dashboard doesn't update. So the PluginWallet remains in an inactive state at all times.
with a Key we force the component to be updated.