### PR TITLE
fix link Launch button

### DIFF
--- a/web/massastation/src/pages/Index/Index.tsx
+++ b/web/massastation/src/pages/Index/Index.tsx
@@ -131,7 +131,10 @@ export function Index() {
                   iconActive={<WalletActive />}
                   iconInactive={<WalletInactive />}
                   onClickActive={() =>
-                    navigate('/plugin/massa-labs/massa-wallet/web-app/index')
+                    window.open(
+                      '/plugin/massa-labs/massa-wallet/web-app/index',
+                      '_blank',
+                    )
                   }
                   onClickInactive={handleInstallPlugin}
                 />,


### PR DESCRIPTION
this will fix:

> 
> When the wallet is installed, and I click on "Launch", I'm redirected to the wallet page. --> KO
> Expected: I want the wallet to be opened in another tab (it is another app so it must open in another tab, contrary to the search or store pages that are part of the same app ;) )

from https://github.com/massalabs/station/issues/822#issuecomment-1603116073