### PR TITLE
stop all plugin on app quit

### DIFF
--- a/cmd/massastation/main.go
+++ b/cmd/massastation/main.go
@@ -71,8 +71,8 @@ func main() {
 	update.StartUpdateCheck(&stationGUI, systrayMenu)
 
 	stationGUI.Lifecycle().SetOnStopped(func() {
-		server.Stop()
 		pluginManager.Stop()
+		server.Stop()
 	})
 	stationGUI.Lifecycle().SetOnStarted(func() {
 		server.Start(networkManager, pluginManager)

--- a/int/api/myplugin/plugin.go
+++ b/int/api/myplugin/plugin.go
@@ -1,29 +1,21 @@
 package myplugin
 
 import (
-	"fmt"
-	"os"
-
 	"github.com/massalabs/station/api/swagger/server/restapi/operations"
 	"github.com/massalabs/station/pkg/plugin"
 )
 
-func InitializePluginAPI(api *operations.MassastationAPI) {
-	manager, err := plugin.NewManager()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "WARN: while starting plugin manager %s.\n", err)
-	}
-
-	api.PluginManagerInstallHandler = newInstall(manager)
-	api.PluginManagerExecuteCommandHandler = newExecute(manager)
-	api.PluginManagerGetInformationHandler = newInfo(manager)
-	api.PluginManagerListHandler = newList(manager)
-	api.PluginManagerRegisterHandler = newRegister(manager)
-	api.PluginManagerUninstallHandler = newUninstall(manager)
-	api.PluginManagerGetLogoHandler = newLogo(manager)
+func InitializePluginAPI(api *operations.MassastationAPI, pluginManager *plugin.Manager) {
+	api.PluginManagerInstallHandler = newInstall(pluginManager)
+	api.PluginManagerExecuteCommandHandler = newExecute(pluginManager)
+	api.PluginManagerGetInformationHandler = newInfo(pluginManager)
+	api.PluginManagerListHandler = newList(pluginManager)
+	api.PluginManagerRegisterHandler = newRegister(pluginManager)
+	api.PluginManagerUninstallHandler = newUninstall(pluginManager)
+	api.PluginManagerGetLogoHandler = newLogo(pluginManager)
 
 	// This endpoint is not defined by the go-swagger API.
-	plugin.Handler = *plugin.NewAPIHandler(manager)
+	plugin.Handler = *plugin.NewAPIHandler(pluginManager)
 }
 
 const (

--- a/pkg/plugin/manager.go
+++ b/pkg/plugin/manager.go
@@ -123,8 +123,10 @@ func (m *Manager) Delete(correlationID string) error {
 	m.mutex.Lock()
 
 	// Ignore Stop errors. We want to delete the plugin anyway
-	//nolint:errcheck
-	plgn.Stop()
+	err = plgn.Stop()
+	if err != nil {
+		config.Logger.Warnf("stopping plugin before delete %s: %s\n", correlationID, err)
+	}
 
 	alias := Alias(plgn.info.Author, plgn.info.Name)
 

--- a/pkg/plugin/manager.go
+++ b/pkg/plugin/manager.go
@@ -44,16 +44,11 @@ type Manager struct {
 }
 
 // NewManager instantiates a manager struct.
-func NewManager() (*Manager, error) {
+func NewManager() *Manager {
 	//nolint:exhaust,exhaustruct
 	manager := &Manager{plugins: make(map[string]*Plugin), authorNameToID: make(map[string]string)}
 
-	err := manager.RunAll()
-	if err != nil {
-		return manager, fmt.Errorf("while running all plugins: %w", err)
-	}
-
-	return manager, nil
+	return manager
 }
 
 // ID returns the list of all the plugin correlationID.
@@ -202,6 +197,17 @@ func (m *Manager) RunAll() error {
 	}
 
 	return nil
+}
+
+func (m *Manager) Stop() {
+	config.Logger.Info("Stopping all plugins...")
+
+	for _, plugin := range m.plugins {
+		err := plugin.Stop()
+		if err != nil {
+			config.Logger.Warnf("Error while stopping plugin %s: %s", plugin.info.Name, err)
+		}
+	}
 }
 
 // DownloadPlugin downloads a plugin from a given URL.


### PR DESCRIPTION
- Refactor: move creation of plugin manager
- run all plugin after starting server (plugins register, they need the server to be started)
- stop all plugins on fyne app stop