### PR TITLE
Remove Scroll Behavior From Home Page

### DIFF
--- a/web/massastation/src/pages/Index/Index.tsx
+++ b/web/massastation/src/pages/Index/Index.tsx
@@ -96,7 +96,7 @@ function NestedIndex({
     <>
       <div className="bg-primary text-f-primary pt-24">
         <h1 className="mas-banner mb-10"> {Intl.t('index.title-banner')}</h1>
-        <div className="overflow-auto h-[65vh]">
+        <div className="overflow-auto">
           <div className="w-[70vw]">
             <div className="flex space-x-8 pb-10">
               <Button


### PR DESCRIPTION
This removes the double scroll present on mac os massaStation application