### PR TITLE
Fix installer logs errors

### DIFF
--- a/installer/windows/build_installer.py
+++ b/installer/windows/build_installer.py
@@ -285,7 +285,7 @@ def create_wxs_file():
         <CustomAction
             Id="InstallAcrylic"
             Directory="AcrylicDNSProxy"
-            ExeCommand="cmd /c &quot;[AcrylicDNSProxy]InstallAcrylicService.bat&quot; >> {INSTALLER_LOGFILE}"
+            ExeCommand="cmd /c &quot;[AcrylicDNSProxy]InstallAcrylicService.bat&quot; >> {INSTALLER_LOGFILE} 2>&amp;1"
             Execute="deferred"
             Impersonate="no"
             Return="check"
@@ -293,7 +293,7 @@ def create_wxs_file():
         <CustomAction
             Id="ConfigureAcrylic"
             Directory="INSTALLDIR"
-            ExeCommand="cmd /c &quot;[INSTALLDIR]{ACRYLIC_CONFIG_SCRIPT}&quot; >> {INSTALLER_LOGFILE}"
+            ExeCommand="cmd /c &quot;[INSTALLDIR]{ACRYLIC_CONFIG_SCRIPT}&quot; >> {INSTALLER_LOGFILE} 2>&amp;1"
             Execute="deferred"
             Impersonate="no"
             Return="check"
@@ -301,7 +301,7 @@ def create_wxs_file():
         <CustomAction
             Id="ConfigureNetworkInterface"
             Directory="INSTALLDIR"
-            ExeCommand="cmd /c &quot;[INSTALLDIR]{NIC_CONFIG_SCRIPT}&quot; >> {INSTALLER_LOGFILE}"
+            ExeCommand="cmd /c &quot;[INSTALLDIR]{NIC_CONFIG_SCRIPT}&quot; >> {INSTALLER_LOGFILE} 2>&amp;1"
             Execute="deferred"
             Impersonate="no"
             Return="check"
@@ -309,7 +309,7 @@ def create_wxs_file():
         <CustomAction
             Id="GenerateCertificate"
             Directory="INSTALLDIR"
-            ExeCommand="cmd /c &quot;[INSTALLDIR]{GEN_CERT_SCRIPT}&quot; >> {INSTALLER_LOGFILE}"
+            ExeCommand="cmd /c &quot;[INSTALLDIR]{GEN_CERT_SCRIPT}&quot; >> {INSTALLER_LOGFILE} 2>&amp;1"
             Execute="deferred"
             Impersonate="no"
             Return="check"
@@ -325,7 +325,7 @@ def create_wxs_file():
         <CustomAction
             Id="ResetNetworkInterface"
             Directory="INSTALLDIR"
-            ExeCommand="cmd /c &quot;[INSTALLDIR]{NIC_RESET_SCRIPT}&quot; >> {INSTALLER_LOGFILE}"
+            ExeCommand="cmd /c &quot;[INSTALLDIR]{NIC_RESET_SCRIPT}&quot; >> {INSTALLER_LOGFILE} 2>&amp;1"
             Execute="deferred"
             Impersonate="no"
             Return="check"

--- a/installer/windows/build_installer.py
+++ b/installer/windows/build_installer.py
@@ -40,6 +40,7 @@ WIXTOOLSET_URL = (
     "https://wixdl.blob.core.windows.net/releases/v3.14.0.6526/wix314-binaries.zip"
 )
 
+INSTALLER_LOGFILE = "%Temp%\\massastation_installer.log"
 
 def download_file(url, filename):
     """
@@ -284,7 +285,7 @@ def create_wxs_file():
         <CustomAction
             Id="InstallAcrylic"
             Directory="AcrylicDNSProxy"
-            ExeCommand="cmd /c &quot;[AcrylicDNSProxy]InstallAcrylicService.bat&quot;"
+            ExeCommand="cmd /c &quot;[AcrylicDNSProxy]InstallAcrylicService.bat&quot; >> {INSTALLER_LOGFILE}"
             Execute="deferred"
             Impersonate="no"
             Return="check"
@@ -292,7 +293,7 @@ def create_wxs_file():
         <CustomAction
             Id="ConfigureAcrylic"
             Directory="INSTALLDIR"
-            ExeCommand="cmd /c &quot;[INSTALLDIR]{ACRYLIC_CONFIG_SCRIPT}&quot;"
+            ExeCommand="cmd /c &quot;[INSTALLDIR]{ACRYLIC_CONFIG_SCRIPT}&quot; >> {INSTALLER_LOGFILE}"
             Execute="deferred"
             Impersonate="no"
             Return="check"
@@ -300,7 +301,7 @@ def create_wxs_file():
         <CustomAction
             Id="ConfigureNetworkInterface"
             Directory="INSTALLDIR"
-            ExeCommand="cmd /c &quot;[INSTALLDIR]{NIC_CONFIG_SCRIPT}&quot;"
+            ExeCommand="cmd /c &quot;[INSTALLDIR]{NIC_CONFIG_SCRIPT}&quot; >> {INSTALLER_LOGFILE}"
             Execute="deferred"
             Impersonate="no"
             Return="check"
@@ -308,7 +309,7 @@ def create_wxs_file():
         <CustomAction
             Id="GenerateCertificate"
             Directory="INSTALLDIR"
-            ExeCommand="cmd /c &quot;[INSTALLDIR]{GEN_CERT_SCRIPT}&quot;"
+            ExeCommand="cmd /c &quot;[INSTALLDIR]{GEN_CERT_SCRIPT}&quot; >> {INSTALLER_LOGFILE}"
             Execute="deferred"
             Impersonate="no"
             Return="check"
@@ -324,7 +325,7 @@ def create_wxs_file():
         <CustomAction
             Id="ResetNetworkInterface"
             Directory="INSTALLDIR"
-            ExeCommand="cmd /c &quot;[INSTALLDIR]{NIC_RESET_SCRIPT}&quot; reset"
+            ExeCommand="cmd /c &quot;[INSTALLDIR]{NIC_RESET_SCRIPT}&quot;"
             Execute="deferred"
             Impersonate="no"
             Return="check"

--- a/installer/windows/build_installer.py
+++ b/installer/windows/build_installer.py
@@ -325,7 +325,7 @@ def create_wxs_file():
         <CustomAction
             Id="ResetNetworkInterface"
             Directory="INSTALLDIR"
-            ExeCommand="cmd /c &quot;[INSTALLDIR]{NIC_RESET_SCRIPT}&quot;"
+            ExeCommand="cmd /c &quot;[INSTALLDIR]{NIC_RESET_SCRIPT}&quot; >> {INSTALLER_LOGFILE}"
             Execute="deferred"
             Impersonate="no"
             Return="check"

--- a/installer/windows/scripts/configure_acrylic.bat
+++ b/installer/windows/scripts/configure_acrylic.bat
@@ -2,12 +2,7 @@
 
 :: Set Acrylic DNS to resolve `.massa` TLD to localhost
 
-set LOG_FILE=%TEMP%\massastation_install.log
-
-:: redirect err and std output of all intructions bellow to the log file 
-(
-
-echo Executing configure_acrylic.bat
+ECHO Executing configure_acrylic.bat
 
 SETLOCAL ENABLEDELAYEDEXPANSION
 
@@ -45,5 +40,3 @@ if %errorlevel% NEQ 0 (
 ENDLOCAL
 
 EXIT 0
-
-) >> %LOG_FILE% 2>&1

--- a/installer/windows/scripts/configure_network_interfaces.bat
+++ b/installer/windows/scripts/configure_network_interfaces.bat
@@ -1,9 +1,4 @@
-@echo off
-
-set LOG_FILE=%TEMP%\massastation_install.log
-
-:: redirect err and std output of all intructions bellow to the log file 
-(
+@ECHO OFF
 
 echo Executing configure_network_interfaces.bat
 
@@ -14,7 +9,7 @@ SETLOCAL ENABLEDELAYEDEXPANSION
 for /f "skip=1 delims=" %%A in ('wmic nic where "netenabled=true" get netconnectionID') do @for /f "delims=" %%B in ("%%A") do (
     SET "networkAdapterName=%%B"
 
-    echo Configuring !networkAdapterName: =!...
+    ECHO Configuring !networkAdapterName: =!...
 
     NETSH interface ipv4 set dnsservers "!networkAdapterName: =!" static 127.0.0.1 primary
     NETSH interface ipv6 set dnsservers "!networkAdapterName: =!" static ::1 primary
@@ -27,5 +22,3 @@ for /f "skip=1 delims=" %%A in ('wmic nic where "netenabled=true" get netconnect
 ENDLOCAL
 
 EXIT 0
-
-) >> %LOG_FILE% 2>&1

--- a/installer/windows/scripts/generate_certificate.bat
+++ b/installer/windows/scripts/generate_certificate.bat
@@ -2,12 +2,7 @@
 
 :: Generate a certificate for the `.massa` TLD
 
-set LOG_FILE=%TEMP%\massastation_install.log
-
-:: redirect err and std output of all intructions bellow to the log file 
-(
-
-echo Executing generate_certificate.bat
+ECHO Executing generate_certificate.bat
 
 SETLOCAL ENABLEDELAYEDEXPANSION
 
@@ -44,5 +39,3 @@ if %ERRORLEVEL% NEQ 0 (
 ENDLOCAL
 
 EXIT 0
-
-) >> %LOG_FILE% 2>&1

--- a/installer/windows/scripts/reset_network_interfaces.bat
+++ b/installer/windows/scripts/reset_network_interfaces.bat
@@ -1,11 +1,6 @@
-@echo off
+@ECHO OFF
 
-set LOG_FILE=%TEMP%\massastation_install.log
-
-:: redirect err and std output of all intructions bellow to the log file 
-(
-
-echo Executing reset_network_interfaces.bat
+ECHO Executing reset_network_interfaces.bat
 
 SETLOCAL ENABLEDELAYEDEXPANSION
 
@@ -13,7 +8,7 @@ SETLOCAL ENABLEDELAYEDEXPANSION
 for /f "skip=1 delims=" %%A in ('wmic nic where "netenabled=true" get netconnectionID') do @for /f "delims=" %%B in ("%%A") do (
     SET "networkAdapterName=%%B"
 
-    echo Configuring !networkAdapterName: =!...
+    ECHO Configuring !networkAdapterName: =!...
 
     NETSH interface ipv4 set dnsservers "!networkAdapterName: =!" dhcp
     NETSH interface ipv6 set dnsservers "!networkAdapterName: =!" dhcp
@@ -29,5 +24,3 @@ for /f "skip=1 delims=" %%A in ('wmic nic where "netenabled=true" get netconnect
 ENDLOCAL
 
 EXIT 0
-
-) >> %LOG_FILE% 2>&1


### PR DESCRIPTION
Fixes some errors due to empty variables. This was due to how we handled logs in those scripts.