### PR TITLE
remove fatal error if the store cannot be fetched

### DIFF
--- a/int/api/server.go
+++ b/int/api/server.go
@@ -97,7 +97,7 @@ func NewServer(flags StartServerFlags) *Server {
 
 	err = store.NewStore()
 	if err != nil {
-		logger.Logger.Fatal(err.Error())
+		logger.Logger.Errorf(err.Error())
 	}
 
 	return &Server{


### PR DESCRIPTION
to test : remove the wifi & run massastation
```
2023-07-06T10:40:20.320+0200    ERROR   api/server.go:150       Could not get node version: calling get_status: rpc call get_status() on https://buildernet.massa.net/api/v2: Post "https://buildernet.massa.net/api/v2": sending http request '&{Method:POST URL:https://buildernet.massa.net/api/v2 Proto:HTTP/1.1 ProtoMajor:1 ProtoMinor:1 Header:map[Accept:[application/json] Content-Type:[application/json]] Body:{Reader:0xc000620120} GetBody:0x6fd460 ContentLength:46 TransferEncoding:[] Close:false Host:buildernet.massa.net Form:map[] PostForm:map[] MultipartForm:<nil> Trailer:map[] RemoteAddr: RequestURI: TLS:<nil> Cancel:<nil> Response:<nil> ctx:0xc0000420d0}': dial tcp: lookup buildernet.massa.net: no such host
2
```