### PR TITLE
return plugin compability in the store

### DIFF
--- a/api/swagger/server/restapi/resource/swagger.yml
+++ b/api/swagger/server/restapi/resource/swagger.yml
@@ -1005,6 +1005,8 @@ definitions:
         type: string
       massastationMinVersion:
         type: string
+      iscompatible:
+        type: boolean
       file:
         $ref: '#/definitions/File'
       os:

--- a/int/api/pluginstore/list.go
+++ b/int/api/pluginstore/list.go
@@ -50,7 +50,8 @@ func (l *list) Handle(_ operations.GetPluginStoreParams) middleware.Responder {
 				URL:      &pluginURL,
 				Checksum: &checksum,
 			},
-			Os: os,
+			Os:           os,
+			Iscompatible: plugin.IsCompatible,
 		}
 	}
 

--- a/pkg/plugin/plugin_test.go
+++ b/pkg/plugin/plugin_test.go
@@ -32,8 +32,11 @@ func AssertUpdate(t *testing.T, testPluginUpdate testPluginUpdate) {
 
 	pluginCompatible, err := pluginInStore.IsPluginCompatible()
 	assert.NoError(t, err)
+
+	pluginInStore.IsCompatible = pluginCompatible
 	assert.Equal(t, pluginCompatible, testPluginUpdate.compatible)
 
+	storeMS.Plugins[0].IsCompatible = pluginCompatible
 	isUpdatable, err := storeMS.CheckForPluginUpdates(plgn.info.Name, plgn.info.Version)
 	assert.NoError(t, err)
 	assert.Equal(t, isUpdatable, testPluginUpdate.updatable)


### PR DESCRIPTION
We're adding a field `isCompatible` that returns true if massa station's version is compatible with the plugin requirements