### PR TITLE
Install plugin macos app

### DIFF
--- a/pkg/plugin/manager_test.go
+++ b/pkg/plugin/manager_test.go
@@ -57,7 +57,7 @@ func Test_removePlugin(t *testing.T) {
 				t.Fatalf("Failed to create temp directory: %v", err)
 			}
 
-			testCase.plugin.BinPath = filepath.Join(tempDir, "pluginBinary")
+			testCase.plugin.Path = tempDir
 
 			// Create dummy files.
 			for _, file := range testCase.createFiles {

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -158,7 +158,6 @@ func prepareBinary(pluginFilename, pluginPath string) error {
 	if _, err := os.Stat(binPath); os.IsNotExist(err) {
 		// If the plugin binary does not exist, it means that the plugin is a MacOS .app directory.
 		// No need to rename the binary.
-
 		// We extract the .app.zip file to the plugin directory
 		appPath := filepath.Join(pluginPath, pluginName+".app")
 

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 
@@ -159,6 +160,10 @@ func prepareBinary(pluginFilename, pluginPath string) error {
 		// If the plugin binary does not exist, it means that the plugin is a MacOS .app directory.
 		// No need to rename the binary.
 		// We extract the .app.zip file to the plugin directory
+		if runtime.GOOS != "darwin" {
+			return fmt.Errorf("plugin binary not found at %s", binPath)
+		}
+
 		appPath := filepath.Join(pluginPath, pluginName+".app")
 
 		err = os.Mkdir(appPath, os.ModePerm)

--- a/web/massastation/src/i18n/en_US.json
+++ b/web/massastation/src/i18n/en_US.json
@@ -15,7 +15,7 @@
       "subtitle": "Paste the link of the zip module",
       "placeholder": "URL",
       "fe-error": "Please enter a valid url",
-      "be-error": "Failed to upload plugin",
+      "be-error": "Failed to install plugin",
       "button": "Install"
     }
   },


### PR DESCRIPTION
Part of https://github.com/massalabs/station-massa-wallet/issues/423

This PR allow plugin manager to install a plugin as a .app directory, for Mac OS application. This allow to have the proper logo in the dock on MacOS.

To test:
write this node js script into `store-mock-sever.js`
```
const http = require('http');
const fs = require('fs');
const path = require('path');

if (process.argv.length !== 3) {
  console.error('Usage: node file-server.js <file-path>');
  process.exit(1);
}

const filePath = process.argv[2];
const fileName = path.basename(filePath);

const server = http.createServer((req, res) => {
  // Set the headers to specify the file download
  res.setHeader('Content-disposition', `attachment; filename=${fileName}`);
  res.setHeader('Content-type', 'application/octet-stream');

  // Read the file and stream it to the response
  const fileStream = fs.createReadStream(filePath);
  fileStream.pipe(res);
});

const port = 3000;
const downloadPath = '/plugin.zip';

server.listen(port, () => {
  console.log(`Server is running on http://localhost:${port}`);
  console.log(`You can download the file at http://localhost:${port}${downloadPath}`);
});
```

Download the wallet plugin artifact here: https://github.com/massalabs/station/actions/runs/6123032359?pr=1147

then run `node store-mock-sever.js ~/Downloads/wallet-plugin_darwin-arm64.zip`

Open Massa Station, install a plugin from a ZIP URL on the right panel: http://localhost:3000/plugin.zip