### PR TITLE
clean code uninstall plugin

### DIFF
--- a/pkg/plugin/manager.go
+++ b/pkg/plugin/manager.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"path"
 	"path/filepath"
-	"strings"
 	"sync"
 
 	"github.com/cavaliergopher/grab/v3"
@@ -169,36 +168,12 @@ func (m *Manager) Delete(correlationID string) error {
 }
 
 // removePlugin removes all the plugin files from the file system.
-// However, for the "massa-labs/massa-wallet" plugin, it keeps the wallet files.
-// The wallet files are identified by the prefix "wallet_" and the suffix ".yaml".
 func removePlugin(plugin *Plugin) error {
 	dir := plugin.Path
 
-	alias := Alias(plugin.info.Author, plugin.info.Name)
-	if alias != "massa-labs/massa-wallet" {
-		err := os.RemoveAll(dir)
-		if err != nil {
-			return fmt.Errorf("removing plugin dir %s: %w", dir, err)
-		}
-
-		return nil
-	}
-
-	// for the massa-wallet we want to keep all the wallet entries
-	entries, err := os.ReadDir(dir)
+	err := os.RemoveAll(dir)
 	if err != nil {
-		return fmt.Errorf("reading plugin dir %s: %w", dir, err)
-	}
-
-	for _, entry := range entries {
-		if !(strings.HasPrefix(entry.Name(), "wallet_") && strings.HasSuffix(entry.Name(), ".yaml")) {
-			item := path.Join(dir, entry.Name())
-
-			err = os.RemoveAll(item)
-			if err != nil {
-				return fmt.Errorf("removing file or directory %s: %w", item, err)
-			}
-		}
+		return fmt.Errorf("removing plugin dir %s: %w", dir, err)
 	}
 
 	return nil

--- a/pkg/plugin/manager_test.go
+++ b/pkg/plugin/manager_test.go
@@ -12,7 +12,6 @@ func Test_removePlugin(t *testing.T) {
 		name        string
 		plugin      *Plugin
 		createFiles []string
-		remainFiles []string
 	}{
 		{
 			name: "massa-labs/massa-wallet",
@@ -23,7 +22,6 @@ func Test_removePlugin(t *testing.T) {
 				},
 			},
 			createFiles: []string{"wallet_test.yaml", "other_file.txt"},
-			remainFiles: []string{"wallet_test.yaml"},
 		},
 		{
 			name: "massa-labs/not-massa-wallet",
@@ -34,7 +32,6 @@ func Test_removePlugin(t *testing.T) {
 				},
 			},
 			createFiles: []string{"wallet_test.yaml", "other_file.txt"},
-			remainFiles: []string{},
 		},
 		{
 			name: "not-massa-labs/massa-wallet",
@@ -45,7 +42,6 @@ func Test_removePlugin(t *testing.T) {
 				},
 			},
 			createFiles: []string{"wallet_test.yaml", "other_file.txt"},
-			remainFiles: []string{},
 		},
 	}
 
@@ -70,14 +66,6 @@ func Test_removePlugin(t *testing.T) {
 			// Call the function to test.
 			if err := removePlugin(testCase.plugin); err != nil {
 				t.Fatalf("Failed to remove plugin: %v", err)
-			}
-
-			// Check if the remaining files still exist.
-			for _, file := range testCase.remainFiles {
-				dummyFile := filepath.Join(tempDir, file)
-				if _, err := os.Stat(dummyFile); os.IsNotExist(err) {
-					t.Fatalf("File was deleted: %v", err)
-				}
 			}
 
 			// Clean up the temporary directory.


### PR DESCRIPTION
Now that wallet account .yaml files are store on another location on the computer that the massa station directory, we can remove the code that kept the .yaml file while deleting the wallet plugin.