### PR TITLE
Clean Plugin Version Display

### DIFF
--- a/web/massastation/package-lock.json
+++ b/web/massastation/package-lock.json
@@ -2613,9 +2613,9 @@
       }
     },
     "node_modules/@massalabs/react-ui-kit": {
-      "version": "0.0.4-dev.20230926132541",
-      "resolved": "https://registry.npmjs.org/@massalabs/react-ui-kit/-/react-ui-kit-0.0.4-dev.20230926132541.tgz",
-      "integrity": "sha512-KmLTXuKsFnp3Fu8jTewTKz74tOJJ+wPgozbnrPatTxrgVrhofLJRJ6VyYk7mGlZsqDv2XAgXgQKvPc7KjafrJg==",
+      "version": "0.0.4-dev.20230926155657",
+      "resolved": "https://registry.npmjs.org/@massalabs/react-ui-kit/-/react-ui-kit-0.0.4-dev.20230926155657.tgz",
+      "integrity": "sha512-esOBtnWO4vZLNPcUZjEg82Sxg7MOkb9guCiLx0BWjW1rpzpRvDywZqOQzbMuUHbL51iKucDmHHz9NjbuoDuRUA==",
       "dependencies": {
         "@headlessui/react": "^1.7.15",
         "@inrupt/jest-jsdom-polyfills": "^2.1.1",

--- a/web/massastation/src/pages/Store/StationSection/StationPlugin.tsx
+++ b/web/massastation/src/pages/Store/StationSection/StationPlugin.tsx
@@ -78,7 +78,7 @@ export function StationPlugin({
     title: name,
     subtitle: author,
     subtitleIcon: massalabsNomination.includes(author) ? <Certificate /> : null,
-    version: `v${version}`,
+    version: version,
   } as PluginProps;
 
   switch (status) {

--- a/web/massastation/src/pages/Store/StoreSection/StorePlugin.tsx
+++ b/web/massastation/src/pages/Store/StoreSection/StorePlugin.tsx
@@ -66,7 +66,7 @@ function StorePlugin(props: StorePluginProps) {
     title: name,
     subtitle: author,
     subtitleIcon: massalabsNomination.includes(author) ? <Certificate /> : null,
-    version: `v${version}`,
+    version: version,
     content: description,
   };
 


### PR DESCRIPTION
This is a follow up PR of https://github.com/massalabs/ui-kit/pull/339. 

Now the "v" string is contained in ui-kit

<img width="1051" alt="Screenshot 2023-09-26 at 18 02 00" src="https://github.com/massalabs/station/assets/90157528/485fc7b1-e728-42eb-a8ef-cfa53b877dc6">


