### PR TITLE
fix plugin is compatible

### DIFF
--- a/api/swagger/server/restapi/resource/swagger.yml
+++ b/api/swagger/server/restapi/resource/swagger.yml
@@ -889,7 +889,7 @@ definitions:
         type: string
       massastationMinVersion:
         type: string
-      iscompatible:
+      isCompatible:
         type: boolean
       file:
         $ref: '#/definitions/File'

--- a/int/api/pluginstore/list.go
+++ b/int/api/pluginstore/list.go
@@ -51,7 +51,7 @@ func (l *list) Handle(_ operations.GetPluginStoreParams) middleware.Responder {
 				Checksum: &checksum,
 			},
 			Os:           os,
-			Iscompatible: plugin.IsCompatible,
+			IsCompatible: plugin.IsCompatible,
 		}
 	}
 

--- a/web/massastation/src/pages/Store/StoreSection/StorePlugin.tsx
+++ b/web/massastation/src/pages/Store/StoreSection/StorePlugin.tsx
@@ -21,7 +21,7 @@ function StorePlugin(props: StorePluginProps) {
     description,
     file: { url },
     version,
-    isCompatible: isCompatible,
+    isCompatible,
     massastationMinVersion,
   } = plugin;
 
@@ -32,7 +32,7 @@ function StorePlugin(props: StorePluginProps) {
     mutate,
     isSuccess: isInstallSuccess,
     isLoading: isInstallLoading,
-  } = usePost(`plugin-manager`);
+  } = usePost('plugin-manager');
 
   const params = { source: url };
 


### PR DESCRIPTION
## Bug
I want to install the wallet plugin but it not possible and there is a warning saying that it requires version 0.3.0 of massa station, I run version 0.6.1 of massa station.

## Fix
This bug is introdoced in version 0.6.1, it was working well in 0.6.0. This PR introduce the bug: https://github.com/massalabs/station/pull/1316

The fix is to rename the variable isCompatible.

## Delivery Quality Checklist

- [ ] **Breaking Changes in API:**
  Does this PR introduce breaking changes in the API?
    - If yes, have you considered making it backward compatible?
    - If backward compatibility is not considered, set the "breaking-change" label.

- [ ] **Changelog:**
  - [ ] For bugfix PR, set the "bugfix" label
  - [ ] If this change should not appear in changelog, use "ignore-for-changelog" label

- [ ] **Version Update Handling:**
  Have you ensured that the version update by user is handled correctly?

- [ ] **PR Dependency:**
  Does this PR depend on another PR?
    - If yes, is it necessary for the dependency to be released prior to merging this one?

- [ ] **Documentation:**
  - [ ] Are any necessary changes made to user-facing documentation?
  - [ ] Confirm that API documentation is updated with any relevant changes.
  - [ ] Check that README and other documentation files are accurate and current.
