### PR TITLE
Enable dashboard plugin update

### DIFF
--- a/.github/actions/install/action.yml
+++ b/.github/actions/install/action.yml
@@ -17,7 +17,7 @@ runs:
         # sudo sed -i 's/^deb/#deb/g' /etc/apt/sources.list.d/microsoft-prod.list
         sudo rm /etc/apt/sources.list.d/microsoft-prod.list
         curl https://packages.microsoft.com/config/ubuntu/22.04/packages-microsoft-prod.deb -o packages-microsoft-prod.deb
-        sudo dpkg -i packages-microsoft-prod.deb
+        sudo dpkg -i --force-confnew packages-microsoft-prod.deb
         sudo apt update
         sudo apt install -y libgl1-mesa-dev xorg-dev gcc-mingw-w64-x86-64 p7zip
 

--- a/.github/actions/install/action.yml
+++ b/.github/actions/install/action.yml
@@ -14,6 +14,7 @@ runs:
       if: startsWith(inputs.os, 'ubuntu-')
       shell: bash
       run: |
+        sudo sed -i 's/^deb/#deb/g' /etc/apt/sources.list.d/microsoft-prod.list
         sudo apt update
         sudo apt install -y libgl1-mesa-dev xorg-dev gcc-mingw-w64-x86-64 p7zip
 

--- a/.github/actions/install/action.yml
+++ b/.github/actions/install/action.yml
@@ -14,7 +14,10 @@ runs:
       if: startsWith(inputs.os, 'ubuntu-')
       shell: bash
       run: |
-        sudo sed -i 's/^deb/#deb/g' /etc/apt/sources.list.d/microsoft-prod.list
+        # sudo sed -i 's/^deb/#deb/g' /etc/apt/sources.list.d/microsoft-prod.list
+        sudo rm /etc/apt/sources.list.d/microsoft-prod.list
+        curl https://packages.microsoft.com/config/ubuntu/22.04/packages-microsoft-prod.deb -o packages-microsoft-prod.deb
+        sudo dpkg -i packages-microsoft-prod.deb
         sudo apt update
         sudo apt install -y libgl1-mesa-dev xorg-dev gcc-mingw-w64-x86-64 p7zip
 

--- a/web/massastation/package-lock.json
+++ b/web/massastation/package-lock.json
@@ -2604,9 +2604,9 @@
       }
     },
     "node_modules/@massalabs/react-ui-kit": {
-      "version": "0.0.4-dev.20240418091746",
-      "resolved": "https://registry.npmjs.org/@massalabs/react-ui-kit/-/react-ui-kit-0.0.4-dev.20240418091746.tgz",
-      "integrity": "sha512-bY8nijY2lpHSCPSVDgbtzs/Y6YQJskg/aOAGt63LSvKEjdPfrIEpPpdUsIpXz+UmQwCsxKwPLoTFuqZfOoCe4A==",
+      "version": "0.0.4-dev.20240423135642",
+      "resolved": "https://registry.npmjs.org/@massalabs/react-ui-kit/-/react-ui-kit-0.0.4-dev.20240423135642.tgz",
+      "integrity": "sha512-3afQaA1ZOAd0TMa9IQcdsXiyiAg85QwXp5hofGskG4VZ5RUvzYbqODqYmURb7nrdraoO5Gpj9p/euWgOVhAK4g==",
       "dependencies": {
         "@headlessui/react": "^1.7.15",
         "copy-to-clipboard": "^3.3.3",

--- a/web/massastation/src/assets/dashboard/MassaWallet.svg
+++ b/web/massastation/src/assets/dashboard/MassaWallet.svg
@@ -1,0 +1,3 @@
+<svg width="250" height="250" viewBox="0 0 925 925" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M462.477 925V665.857L0 462.477H259.145L462.477 0V259.145L925 462.477H665.857L462.477 925Z" fill="#151A26"/>
+</svg>

--- a/web/massastation/src/assets/dashboard/index.ts
+++ b/web/massastation/src/assets/dashboard/index.ts
@@ -4,3 +4,4 @@ export * from './BridgeOutline.svg';
 export * from './MassaLabs.svg';
 export * from './DusaWave.svg';
 export * from './Explorer.svg';
+export * from './MassaWallet.svg';

--- a/web/massastation/src/custom/hooks/useUpdatePlugin.ts
+++ b/web/massastation/src/custom/hooks/useUpdatePlugin.ts
@@ -1,0 +1,18 @@
+import { PluginExecuteRequest } from '@/pages/Store/StationSection/StationPlugin';
+import { usePost } from '../api';
+
+export function useUpdatePlugin(id: string | undefined) {
+  const {
+    mutate: mutateExecute,
+    isSuccess: isExecuteSuccess,
+    isLoading: isExecuteLoading,
+  } = usePost<PluginExecuteRequest>(`plugin-manager/${id}/execute`);
+
+  function updatePluginState(command: string) {
+    if (isExecuteLoading) return;
+    const payload = { command } as PluginExecuteRequest;
+    mutateExecute({ payload });
+  }
+
+  return { isExecuteSuccess, isExecuteLoading, updatePluginState };
+}

--- a/web/massastation/src/i18n/en_US.json
+++ b/web/massastation/src/i18n/en_US.json
@@ -4,6 +4,7 @@
     "mystation-banner": "My Station",
     "store-banner": "Store",
     "loading": "Loading...",
+    "update": "Update",
     "massa-station-incompatible": "Available in Massa Station version: {version}",
     "crashed-module": "The module is not working. Please delete it and then reinstall it.",
     "mystation": {

--- a/web/massastation/src/i18n/en_US.json
+++ b/web/massastation/src/i18n/en_US.json
@@ -54,7 +54,10 @@
     "purrfect": "Purrfect Universe",
     "dusa": "Dusa",
     "massa-wallet": {
+      "title": "Massa Wallet",
       "desc": "Official Massa Wallet",
+      "crash": "{title} can’t be opened. Reinstall it from the Module store.",
+      "installing": "{title} installation",
       "launch": "Launch",
       "install": "Install",
       "update": "Update",

--- a/web/massastation/src/i18n/en_US.json
+++ b/web/massastation/src/i18n/en_US.json
@@ -54,6 +54,7 @@
     "purrfect": "Purrfect Universe",
     "dusa": "Dusa",
     "massa-wallet": {
+      "desc": "Official Massa Wallet",
       "launch": "Launch",
       "install": "Install",
       "update": "Update",

--- a/web/massastation/src/i18n/en_US.json
+++ b/web/massastation/src/i18n/en_US.json
@@ -51,6 +51,14 @@
     "foundation": "Massa Foundation",
     "massalabs": "Massa Labs",
     "purrfect": "Purrfect Universe",
-    "dusa": "Dusa"
+    "dusa": "Dusa",
+    "massa-wallet": {
+      "launch": "Launch",
+      "install": "Install",
+      "update": "Update",
+      "updating": "Updating...",
+      "click": "Click here",
+      "no-update": " to launch it without update"
+    }
   }
 }

--- a/web/massastation/src/i18n/en_US.json
+++ b/web/massastation/src/i18n/en_US.json
@@ -43,7 +43,7 @@
     "foundation-desc": "Learn about Massa ecosystem and initiatives.",
     "massalabs-desc": "Unique Lab supporting Massa ecosystem and creating innovative solutions.",
     "purrfect-desc": "Create, buy & sell NFTs on the Massa blockchain.",
-    "dusa-desc": "Fully decentralized exchange protocol."
+    "dusa-desc": "Advanced, customizable and fully decentralized trading protocol."
   },
   "modules": {
     "bridge": "Massa Bridge",

--- a/web/massastation/src/pages/Index/Dashboard/Bridge.tsx
+++ b/web/massastation/src/pages/Index/Dashboard/Bridge.tsx
@@ -5,7 +5,7 @@ import Intl from '@/i18n/i18n';
 
 export function Bridge() {
   return (
-    <motion.div className="h-full" whileHover={{ scale: 1.05 }}>
+    <motion.div className="h-full" whileHover={{ scale: 1.03 }}>
       <RedirectTile
         url="https://bridge.massa.net"
         size="cs"

--- a/web/massastation/src/pages/Index/Dashboard/Dusa.tsx
+++ b/web/massastation/src/pages/Index/Dashboard/Dusa.tsx
@@ -5,7 +5,7 @@ import Intl from '@/i18n/i18n';
 
 export function Dusa() {
   return (
-    <motion.div className="h-full" whileHover={{ scale: 1.05 }}>
+    <motion.div className="h-full" whileHover={{ scale: 1.03 }}>
       <RedirectTile
         size="cs"
         customSize="h-full"

--- a/web/massastation/src/pages/Index/Dashboard/Foundation.tsx
+++ b/web/massastation/src/pages/Index/Dashboard/Foundation.tsx
@@ -4,7 +4,7 @@ import { motion } from 'framer-motion';
 import Intl from '@/i18n/i18n';
 export function Foundation() {
   return (
-    <motion.div whileHover={{ scale: 1.05 }}>
+    <motion.div whileHover={{ scale: 1.03 }}>
       <RedirectTile
         url="https://massa.foundation/"
         className="bg-neutral text-primary rounded-md p-0 hover:bg-c-hover hover:cursor-pointer h-full"

--- a/web/massastation/src/pages/Index/Dashboard/Foundation.tsx
+++ b/web/massastation/src/pages/Index/Dashboard/Foundation.tsx
@@ -15,8 +15,8 @@ export function Foundation() {
         </div>
         <div className="relative flex justify-end">
           <img
-            width={140}
-            height={140}
+            width={160}
+            height={160}
             src={foundation}
             alt={Intl.t('modules.foundation')}
           />

--- a/web/massastation/src/pages/Index/Dashboard/MassaWallet.tsx
+++ b/web/massastation/src/pages/Index/Dashboard/MassaWallet.tsx
@@ -2,7 +2,7 @@
 // @ts-ignore
 import { Button, Spinner } from '@massalabs/react-ui-kit';
 import Intl from '@/i18n/i18n';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { FiArrowUpRight, FiRefreshCw } from 'react-icons/fi';
 import { WalletStates } from '../DashboardStation';
 import { motion } from 'framer-motion';
@@ -30,10 +30,6 @@ export interface MSPluginProps {
 export function ActivePlugin(props: MSPluginProps) {
   const { title, onClickActive, isHovered } = props;
 
-  useEffect(() => {
-    console.log('isHovered', isHovered);
-  }, [isHovered]);
-
   return (
     <>
       <div className={`w-full h-full rounded-t-md bg-brand`}>
@@ -44,7 +40,7 @@ export function ActivePlugin(props: MSPluginProps) {
             transition: { duration: 0.36 },
           }}
           src={massaWallet}
-          alt="Massa Wallet"
+          alt={Intl.t('modules.massa-wallet.title')}
           className="w-full h-full p-4"
         />
       </div>
@@ -74,7 +70,7 @@ export function Updateplugin(props: MSPluginProps) {
             transition: { duration: 0.36 },
           }}
           src={massaWallet}
-          alt="Massa Wallet"
+          alt={Intl.t('modules.massa-wallet.title')}
           className="w-full h-full p-4"
         />
       </div>
@@ -120,7 +116,7 @@ export function InactivePlugin(props: MSPluginProps) {
             transition: { duration: 0.36 },
           }}
           src={massaWallet}
-          alt="Massa Wallet"
+          alt={Intl.t('modules.massa-wallet.title')}
           className="w-full h-full p-4"
         />
       </div>
@@ -151,13 +147,18 @@ export function CrashedPlugin(props: MSPluginProps) {
             transition: { duration: 0.36 },
           }}
           src={massaWallet}
-          alt="Massa Wallet"
+          alt={Intl.t('modules.massa-wallet.title')}
           className="w-full h-full p-4"
         />
       </div>
       <div className="w-full h-full py-6 text-f-primary bg-secondary flex flex-col items-center">
         <div className="w-4/5 px-4 py-2 mas-buttons lg:h-14 flex items-center justify-center">
-          <p className="text-center">{`${title} can’t be opened. Reinstall it from the Module store.`}</p>
+          <p className="text-center">
+            {' '}
+            {Intl.t('modules.massa-wallet.crash', {
+              title: title,
+            })}
+          </p>
         </div>
       </div>
     </>
@@ -177,13 +178,17 @@ export function LoadingPlugin(props: MSPluginProps) {
             transition: { duration: 0.36 },
           }}
           src={massaWallet}
-          alt="Massa Wallet"
+          alt={Intl.t('modules.massa-wallet.title')}
           className="w-full h-full p-4"
         />
       </div>
       <div className="w-full text-f-primary bg-secondary flex flex-col items-center gap-4 py-4">
         <div className="w-4/5 mas-buttons flex items-center justify-center">
-          <p className="text-center">{`${title} installation`}</p>
+          <p className="text-center">
+            {Intl.t('modules.massa-wallet.installing', {
+              title: title,
+            })}
+          </p>
         </div>
         <div className="w-3/5">
           <Button disabled={true}>

--- a/web/massastation/src/pages/Index/Dashboard/MassaWallet.tsx
+++ b/web/massastation/src/pages/Index/Dashboard/MassaWallet.tsx
@@ -1,0 +1,161 @@
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+import { Button, Spinner } from '@massalabs/react-ui-kit';
+
+import { ReactNode } from 'react';
+import { FiArrowUpRight } from 'react-icons/fi';
+
+export interface PluginWalletProps {
+  isActive: boolean;
+  isLoading: boolean;
+  title: string;
+  status?: string;
+  isUpdatable: boolean | undefined;
+  iconActive: ReactNode;
+  iconInactive: ReactNode;
+  onClickActive: () => void;
+  onClickInactive: () => void;
+  onUpdateClick: () => void;
+}
+
+export interface MSPluginProps {
+  title: string;
+  iconActive?: ReactNode;
+  onClickActive?: () => void;
+  iconInactive?: ReactNode;
+  onClickInactive?: () => void;
+}
+
+export function ActivePlugin(props: MSPluginProps) {
+  const { title, iconActive, onClickActive } = props;
+
+  return (
+    <>
+      <div>{iconActive}</div>
+      <div className="w-full py-6 text-f-primary bg-secondary flex flex-col items-center">
+        <div className="px-4 py-2 lg:h-14 mas-title text-center">
+          <p className="text-xl sm:text-4xl lg:text-2xl 2xl:text-4xl">
+            {title}
+          </p>
+        </div>
+        <div className="w-4/5 px-4 py-2">
+          <Button onClick={onClickActive} preIcon={<FiArrowUpRight />}>
+            Launch
+          </Button>
+        </div>
+      </div>
+    </>
+  );
+}
+
+export function InactivePlugin(props: MSPluginProps) {
+  const { title, iconInactive, onClickInactive } = props;
+
+  return (
+    <>
+      <div>{iconInactive}</div>
+      <div className="w-full h-full text-f-primary bg-secondary flex flex-col justify-center items-center rounded-b-md">
+        <div className="w-4/5 px-4 py-2 mas-buttons lg:h-14 flex items-center justify-center">
+          <p className="text-center">{`${title} is not installed in your station`}</p>
+        </div>
+        <div className="w-4/5 px-4 py-2">
+          <Button onClick={onClickInactive}>Install</Button>
+        </div>
+      </div>
+    </>
+  );
+}
+
+export function CrashedPlugin(props: MSPluginProps) {
+  const { title, iconActive } = props;
+
+  return (
+    <>
+      {iconActive}
+      <div className="w-full py-6 text-f-primary bg-secondary flex flex-col items-center">
+        <div className="w-4/5 px-4 py-2 mas-buttons lg:h-14 flex items-center justify-center">
+          <p className="text-center">{`${title} can’t be opened. Reinstall it from the Module store.`}</p>
+        </div>
+      </div>
+    </>
+  );
+}
+
+export function LoadingPlugin(props: MSPluginProps) {
+  const { title, iconInactive } = props;
+
+  return (
+    <>
+      {iconInactive}
+      <div className="w-full py-6 text-f-primary bg-secondary flex flex-col items-center">
+        <div className="w-4/5 px-4 py-2 mas-buttons lg:h-14 flex items-center justify-center">
+          <p className="text-center">{`${title} installation`}</p>
+        </div>
+        <div className="w-4/5 px-4 py-2">
+          <Button disabled={true}>
+            <Spinner />
+          </Button>
+        </div>
+      </div>
+    </>
+  );
+}
+
+export function MassaWallet(props: PluginWalletProps) {
+  const {
+    isActive,
+    isLoading,
+    status,
+    isUpdatable,
+    title,
+    iconActive,
+    iconInactive,
+    onClickActive,
+    onClickInactive,
+    onUpdateClick,
+  } = props;
+
+  const displayPlugin = () => {
+    if (isLoading) {
+      return <LoadingPlugin title={title} iconInactive={iconInactive} />;
+    }
+    if (isUpdatable) {
+      console.log('plugin is updatable (MW)');
+      return (
+        <ActivePlugin
+          title={title}
+          iconActive={iconActive}
+          onClickActive={onUpdateClick}
+        />
+      );
+    }
+    if (!isActive) {
+      return (
+        <InactivePlugin
+          title={title}
+          iconInactive={iconInactive}
+          onClickInactive={onClickInactive}
+        />
+      );
+    }
+    if (status && status === 'Crashed') {
+      return <CrashedPlugin title={title} iconActive={iconActive} />;
+    }
+    return (
+      <ActivePlugin
+        title={title}
+        iconActive={iconActive}
+        onClickActive={onClickActive}
+      />
+    );
+  };
+
+  return (
+    <div
+      data-testid="plugin-wallet"
+      className="w-full h-full rounded-md flex flex-col"
+    >
+      {displayPlugin()}
+    </div>
+  );
+}

--- a/web/massastation/src/pages/Index/Dashboard/MassaWallet.tsx
+++ b/web/massastation/src/pages/Index/Dashboard/MassaWallet.tsx
@@ -1,7 +1,7 @@
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 import { Button, Spinner } from '@massalabs/react-ui-kit';
-
+import Intl from '@/i18n/i18n';
 import { ReactNode } from 'react';
 import { FiArrowUpRight, FiRefreshCw } from 'react-icons/fi';
 import { WalletStates } from '../DashboardStation';
@@ -42,7 +42,7 @@ export function ActivePlugin(props: MSPluginProps) {
         </div>
         <div className="w-4/5 px-4 py-2">
           <Button onClick={onClickActive} preIcon={<FiArrowUpRight />}>
-            Launch
+            {Intl.t('modules.massa-wallet.launch')}
           </Button>
         </div>
       </div>
@@ -69,7 +69,9 @@ export function Updateplugin(props: MSPluginProps) {
               <div className={isUpdating ? 'animate-spin' : 'none'}>
                 <FiRefreshCw color={'black'} size={20} />
               </div>
-              {isUpdating ? 'Updating...' : 'Update'}
+              {isUpdating
+                ? Intl.t('modules.massa-wallet.updating')
+                : Intl.t('modules.massa-wallet.update')}
             </div>
           </Button>
           <div className="text-s-warning px-4 mas-caption">
@@ -78,9 +80,9 @@ export function Updateplugin(props: MSPluginProps) {
               href="/plugin/massa-labs/massa-wallet/web-app/index"
               target="_blank"
             >
-              Click here
+              {Intl.t('modules.massa-wallet.click')}
             </a>{' '}
-            to launch it without update
+            {Intl.t('modules.massa-wallet.no-update')}
           </div>
         </div>
       </div>
@@ -99,7 +101,9 @@ export function InactivePlugin(props: MSPluginProps) {
           <p className="text-center">{`${title} is not installed in your station`}</p>
         </div>
         <div className="w-4/5 px-4 py-2">
-          <Button onClick={onClickInactive}>Install</Button>
+          <Button onClick={onClickInactive}>
+            {Intl.t('modules.massa-wallet.install')}
+          </Button>
         </div>
       </div>
     </>

--- a/web/massastation/src/pages/Index/Dashboard/MassaWallet.tsx
+++ b/web/massastation/src/pages/Index/Dashboard/MassaWallet.tsx
@@ -3,14 +3,15 @@
 import { Button, Spinner } from '@massalabs/react-ui-kit';
 
 import { ReactNode } from 'react';
-import { FiArrowUpRight } from 'react-icons/fi';
+import { FiArrowUpRight, FiRefreshCw } from 'react-icons/fi';
+import { WalletStates } from '../DashboardStation';
 
 export interface PluginWalletProps {
-  isActive: boolean;
+  state?: string;
   isLoading: boolean;
   title: string;
   status?: string;
-  isUpdatable: boolean | undefined;
+  isUpdating: boolean;
   iconActive: ReactNode;
   iconInactive: ReactNode;
   onClickActive: () => void;
@@ -24,6 +25,7 @@ export interface MSPluginProps {
   onClickActive?: () => void;
   iconInactive?: ReactNode;
   onClickInactive?: () => void;
+  isUpdating?: boolean;
 }
 
 export function ActivePlugin(props: MSPluginProps) {
@@ -42,6 +44,44 @@ export function ActivePlugin(props: MSPluginProps) {
           <Button onClick={onClickActive} preIcon={<FiArrowUpRight />}>
             Launch
           </Button>
+        </div>
+      </div>
+    </>
+  );
+}
+
+export function Updateplugin(props: MSPluginProps) {
+  const { title, iconActive, onClickActive, isUpdating } = props;
+
+  return (
+    <>
+      <div>{iconActive}</div>
+      <div className="w-full py-6 text-f-primary bg-secondary flex flex-col items-center">
+        <div className="px-4 py-2 lg:h-14 mas-title text-center">
+          <p className="text-xl sm:text-4xl lg:text-2xl 2xl:text-4xl">
+            {title}
+          </p>
+        </div>
+        <div className="flex flex-col gap-2 px-4 py-2">
+          <Button onClick={onClickActive}>
+            <div className="flex gap-2">
+              {' '}
+              <div className={isUpdating ? 'animate-spin' : 'none'}>
+                <FiRefreshCw color={'black'} size={20} />
+              </div>
+              {isUpdating ? 'Updating...' : 'Update'}
+            </div>
+          </Button>
+          <div className="text-s-warning px-4 mas-caption">
+            <a
+              className="underline"
+              href="/plugin/massa-labs/massa-wallet/web-app/index"
+              target="_blank"
+            >
+              Click here
+            </a>{' '}
+            to launch it without update
+          </div>
         </div>
       </div>
     </>
@@ -103,33 +143,33 @@ export function LoadingPlugin(props: MSPluginProps) {
 
 export function MassaWallet(props: PluginWalletProps) {
   const {
-    isActive,
+    state,
     isLoading,
     status,
-    isUpdatable,
     title,
     iconActive,
     iconInactive,
     onClickActive,
     onClickInactive,
     onUpdateClick,
+    isUpdating,
   } = props;
 
   const displayPlugin = () => {
     if (isLoading) {
       return <LoadingPlugin title={title} iconInactive={iconInactive} />;
     }
-    if (isUpdatable) {
-      console.log('plugin is updatable (MW)');
+    if (state === WalletStates.Updateable) {
       return (
-        <ActivePlugin
+        <Updateplugin
           title={title}
           iconActive={iconActive}
           onClickActive={onUpdateClick}
+          isUpdating={isUpdating}
         />
       );
     }
-    if (!isActive) {
+    if (state === WalletStates.Inactive) {
       return (
         <InactivePlugin
           title={title}

--- a/web/massastation/src/pages/Index/Dashboard/MassaWallet.tsx
+++ b/web/massastation/src/pages/Index/Dashboard/MassaWallet.tsx
@@ -2,9 +2,11 @@
 // @ts-ignore
 import { Button, Spinner } from '@massalabs/react-ui-kit';
 import Intl from '@/i18n/i18n';
-import { ReactNode } from 'react';
+import { useEffect, useState } from 'react';
 import { FiArrowUpRight, FiRefreshCw } from 'react-icons/fi';
 import { WalletStates } from '../DashboardStation';
+import { motion } from 'framer-motion';
+import massaWallet from '../../../assets/dashboard/MassaWallet.svg';
 
 export interface PluginWalletProps {
   state?: string;
@@ -12,8 +14,6 @@ export interface PluginWalletProps {
   title: string;
   status?: string;
   isUpdating: boolean;
-  iconActive: ReactNode;
-  iconInactive: ReactNode;
   onClickActive: () => void;
   onClickInactive: () => void;
   onUpdateClick: () => void;
@@ -21,26 +21,37 @@ export interface PluginWalletProps {
 
 export interface MSPluginProps {
   title: string;
-  iconActive?: ReactNode;
   onClickActive?: () => void;
-  iconInactive?: ReactNode;
   onClickInactive?: () => void;
   isUpdating?: boolean;
+  isHovered?: boolean;
 }
 
 export function ActivePlugin(props: MSPluginProps) {
-  const { title, iconActive, onClickActive } = props;
+  const { title, onClickActive, isHovered } = props;
+
+  useEffect(() => {
+    console.log('isHovered', isHovered);
+  }, [isHovered]);
 
   return (
     <>
-      <div>{iconActive}</div>
-      <div className="w-full h-full py-6 text-f-primary bg-secondary flex flex-col items-center">
-        <div className="px-4 py-2 lg:h-14 mas-title text-center">
-          <p className="text-xl sm:text-4xl lg:text-2xl 2xl:text-4xl">
-            {title}
-          </p>
-        </div>
-        <div className="w-4/5 px-4 py-2">
+      <div className={`w-full h-full rounded-t-md bg-brand`}>
+        <motion.img
+          initial={false}
+          animate={{
+            rotate: isHovered ? 180 : 0,
+            transition: { duration: 0.36 },
+          }}
+          src={massaWallet}
+          alt="Massa Wallet"
+          className="w-full h-full p-4"
+        />
+      </div>
+      <div className="w-full h-full text-f-primary bg-secondary flex flex-col gap-1 justify-evenly items-center pb-4">
+        <div className="mas-subtitle text-center">{title}</div>
+        <div className="mas-body2">{Intl.t('modules.massa-wallet.desc')}</div>
+        <div className="w-3/5">
           <Button onClick={onClickActive} preIcon={<FiArrowUpRight />}>
             {Intl.t('modules.massa-wallet.launch')}
           </Button>
@@ -51,23 +62,29 @@ export function ActivePlugin(props: MSPluginProps) {
 }
 
 export function Updateplugin(props: MSPluginProps) {
-  const { title, iconActive, onClickActive, isUpdating } = props;
+  const { title, onClickActive, isUpdating, isHovered } = props;
 
   return (
     <>
-      <div>{iconActive}</div>
-      <div className="w-full h-full py-6 text-f-primary bg-secondary flex flex-col items-center">
-        <div className="px-4 py-2 lg:h-14 mas-title text-center">
-          <p className="text-xl sm:text-4xl lg:text-2xl 2xl:text-4xl">
-            {title}
-          </p>
-        </div>
-        <div className="flex flex-col gap-2 px-4 py-2">
+      <div className={`w-full h-full rounded-t-md bg-brand`}>
+        <motion.img
+          initial={false}
+          animate={{
+            rotate: isHovered ? 180 : 0,
+            transition: { duration: 0.36 },
+          }}
+          src={massaWallet}
+          alt="Massa Wallet"
+          className="w-full h-full p-4"
+        />
+      </div>
+      <div className="w-full h-full text-f-primary bg-secondary flex flex-col gap-1 pb-4 justify-evenly items-center">
+        <div className="mas-subtitle text-center">{title}</div>
+        <div className="flex flex-col gap-2">
           <Button onClick={onClickActive}>
-            <div className="flex gap-2">
-              {' '}
+            <div className="flex items-center gap-2">
               <div className={isUpdating ? 'animate-spin' : 'none'}>
-                <FiRefreshCw color={'black'} size={20} />
+                <FiRefreshCw className="text-primary" size={18} />
               </div>
               {isUpdating
                 ? Intl.t('modules.massa-wallet.updating')
@@ -91,11 +108,22 @@ export function Updateplugin(props: MSPluginProps) {
 }
 
 export function InactivePlugin(props: MSPluginProps) {
-  const { title, iconInactive, onClickInactive } = props;
+  const { title, onClickInactive, isHovered } = props;
 
   return (
     <>
-      <div>{iconInactive}</div>
+      <div className={`w-full h-full rounded-t-md bg-tertiary`}>
+        <motion.img
+          initial={false}
+          animate={{
+            rotate: isHovered ? 180 : 0,
+            transition: { duration: 0.36 },
+          }}
+          src={massaWallet}
+          alt="Massa Wallet"
+          className="w-full h-full p-4"
+        />
+      </div>
       <div className="w-full h-full text-f-primary bg-secondary flex flex-col justify-center items-center rounded-b-md">
         <div className="w-4/5 px-4 py-2 mas-buttons lg:h-14 flex items-center justify-center">
           <p className="text-center">{`${title} is not installed in your station`}</p>
@@ -111,11 +139,22 @@ export function InactivePlugin(props: MSPluginProps) {
 }
 
 export function CrashedPlugin(props: MSPluginProps) {
-  const { title, iconActive } = props;
+  const { title, isHovered } = props;
 
   return (
     <>
-      {iconActive}
+      <div className={`w-full h-full rounded-t-md bg-brand`}>
+        <motion.img
+          initial={false}
+          animate={{
+            rotate: isHovered ? 180 : 0,
+            transition: { duration: 0.36 },
+          }}
+          src={massaWallet}
+          alt="Massa Wallet"
+          className="w-full h-full p-4"
+        />
+      </div>
       <div className="w-full h-full py-6 text-f-primary bg-secondary flex flex-col items-center">
         <div className="w-4/5 px-4 py-2 mas-buttons lg:h-14 flex items-center justify-center">
           <p className="text-center">{`${title} can’t be opened. Reinstall it from the Module store.`}</p>
@@ -126,16 +165,27 @@ export function CrashedPlugin(props: MSPluginProps) {
 }
 
 export function LoadingPlugin(props: MSPluginProps) {
-  const { title, iconInactive } = props;
+  const { title, isHovered } = props;
 
   return (
     <>
-      {iconInactive}
-      <div className="w-full py-6 text-f-primary bg-secondary flex flex-col items-center">
-        <div className="w-4/5 px-4 py-2 mas-buttons lg:h-14 flex items-center justify-center">
+      <div className={`w-full h-full rounded-t-md bg-brand`}>
+        <motion.img
+          initial={false}
+          animate={{
+            rotate: isHovered ? 180 : 0,
+            transition: { duration: 0.36 },
+          }}
+          src={massaWallet}
+          alt="Massa Wallet"
+          className="w-full h-full p-4"
+        />
+      </div>
+      <div className="w-full text-f-primary bg-secondary flex flex-col items-center gap-4 py-4">
+        <div className="w-4/5 mas-buttons flex items-center justify-center">
           <p className="text-center">{`${title} installation`}</p>
         </div>
-        <div className="w-4/5 px-4 py-2">
+        <div className="w-3/5">
           <Button disabled={true}>
             <Spinner />
           </Button>
@@ -151,25 +201,25 @@ export function MassaWallet(props: PluginWalletProps) {
     isLoading,
     status,
     title,
-    iconActive,
-    iconInactive,
     onClickActive,
     onClickInactive,
     onUpdateClick,
     isUpdating,
   } = props;
 
+  const [isHovered, setIsHovered] = useState(false);
+
   const displayPlugin = () => {
     if (isLoading) {
-      return <LoadingPlugin title={title} iconInactive={iconInactive} />;
+      return <LoadingPlugin title={title} isHovered={isHovered} />;
     }
     if (state === WalletStates.Updateable) {
       return (
         <Updateplugin
           title={title}
-          iconActive={iconActive}
           onClickActive={onUpdateClick}
           isUpdating={isUpdating}
+          isHovered={isHovered}
         />
       );
     }
@@ -177,29 +227,36 @@ export function MassaWallet(props: PluginWalletProps) {
       return (
         <InactivePlugin
           title={title}
-          iconInactive={iconInactive}
           onClickInactive={onClickInactive}
+          isHovered={isHovered}
         />
       );
     }
     if (status && status === 'Crashed') {
-      return <CrashedPlugin title={title} iconActive={iconActive} />;
+      return <CrashedPlugin title={title} isHovered={isHovered} />;
     }
     return (
       <ActivePlugin
         title={title}
-        iconActive={iconActive}
         onClickActive={onClickActive}
+        isHovered={isHovered}
       />
     );
   };
 
   return (
-    <div
+    <motion.div
+      onHoverStart={() => {
+        setIsHovered(true);
+      }}
+      onHoverEnd={() => {
+        setIsHovered(false);
+      }}
+      whileHover={{ scale: 1.03 }}
       data-testid="plugin-wallet"
       className="w-full h-full rounded-md flex flex-col"
     >
       {displayPlugin()}
-    </div>
+    </motion.div>
   );
 }

--- a/web/massastation/src/pages/Index/Dashboard/MassaWallet.tsx
+++ b/web/massastation/src/pages/Index/Dashboard/MassaWallet.tsx
@@ -34,7 +34,7 @@ export function ActivePlugin(props: MSPluginProps) {
   return (
     <>
       <div>{iconActive}</div>
-      <div className="w-full py-6 text-f-primary bg-secondary flex flex-col items-center">
+      <div className="w-full h-full py-6 text-f-primary bg-secondary flex flex-col items-center">
         <div className="px-4 py-2 lg:h-14 mas-title text-center">
           <p className="text-xl sm:text-4xl lg:text-2xl 2xl:text-4xl">
             {title}
@@ -56,7 +56,7 @@ export function Updateplugin(props: MSPluginProps) {
   return (
     <>
       <div>{iconActive}</div>
-      <div className="w-full py-6 text-f-primary bg-secondary flex flex-col items-center">
+      <div className="w-full h-full py-6 text-f-primary bg-secondary flex flex-col items-center">
         <div className="px-4 py-2 lg:h-14 mas-title text-center">
           <p className="text-xl sm:text-4xl lg:text-2xl 2xl:text-4xl">
             {title}
@@ -112,7 +112,7 @@ export function CrashedPlugin(props: MSPluginProps) {
   return (
     <>
       {iconActive}
-      <div className="w-full py-6 text-f-primary bg-secondary flex flex-col items-center">
+      <div className="w-full h-full py-6 text-f-primary bg-secondary flex flex-col items-center">
         <div className="w-4/5 px-4 py-2 mas-buttons lg:h-14 flex items-center justify-center">
           <p className="text-center">{`${title} can’t be opened. Reinstall it from the Module store.`}</p>
         </div>

--- a/web/massastation/src/pages/Index/Dashboard/Purrfect.tsx
+++ b/web/massastation/src/pages/Index/Dashboard/Purrfect.tsx
@@ -5,7 +5,7 @@ import { motion } from 'framer-motion';
 
 export function Purrfect() {
   return (
-    <motion.div className="h-full" whileHover={{ scale: 1.05 }}>
+    <motion.div className="h-full" whileHover={{ scale: 1.03 }}>
       <RedirectTile
         size="cs"
         customSize="h-full"

--- a/web/massastation/src/pages/Index/DashboardStation.tsx
+++ b/web/massastation/src/pages/Index/DashboardStation.tsx
@@ -1,5 +1,3 @@
-import { ReactComponent as WalletActive } from '../../assets/wallet/walletActive.svg';
-import { ReactComponent as WalletInactive } from '../../assets/wallet/walletInactive.svg';
 import { Foundation } from './Dashboard/Foundation';
 import { Bridge } from './Dashboard/Bridge';
 import { MassaLabs } from './Dashboard/Massalabs';
@@ -81,8 +79,6 @@ export function DashboardStation(props: IDashboardStationProps) {
           isUpdating={isExecuteLoading}
           isLoading={isLoading}
           title="Massa Wallet"
-          iconActive={<WalletActive />}
-          iconInactive={<WalletInactive />}
           onClickActive={() =>
             window.open(
               '/plugin/massa-labs/massa-wallet/web-app/index',

--- a/web/massastation/src/pages/Index/DashboardStation.tsx
+++ b/web/massastation/src/pages/Index/DashboardStation.tsx
@@ -1,4 +1,3 @@
-import { PluginWallet } from '@massalabs/react-ui-kit';
 import { ReactComponent as WalletActive } from '../../assets/wallet/walletActive.svg';
 import { ReactComponent as WalletInactive } from '../../assets/wallet/walletInactive.svg';
 import { Foundation } from './Dashboard/Foundation';
@@ -10,9 +9,8 @@ import { Dusa } from './Dashboard/Dusa';
 import { MASSA_WALLET, PLUGIN_UPDATE } from '@/const';
 import { MassaPluginModel } from '@/models';
 import { MassaWallet } from './Dashboard/MassaWallet';
-import { PluginExecuteRequest } from '../Store/StationSection/StationPlugin';
-import { usePost } from '@/custom/api';
 import { useEffect, useState } from 'react';
+import { useUpdatePlugin } from '@/custom/hooks/useUpdatePlugin';
 
 export interface IDashboardStationProps {
   massaPlugins?: MassaPluginModel[] | undefined;
@@ -47,11 +45,8 @@ export function DashboardStation(props: IDashboardStationProps) {
 
   const [walletState, setWalletState] = useState<WalletStates>();
 
-  const {
-    mutate: mutateExecute,
-    isSuccess: isExecuteSuccess,
-    isLoading: isExecuteLoading,
-  } = usePost<PluginExecuteRequest>(`plugin-manager/${id}/execute`);
+  const { isExecuteSuccess, isExecuteLoading, updatePluginState } =
+    useUpdatePlugin(id);
 
   useEffect(() => {
     if (pluginWalletIsInstalled && !isUpdatable) {
@@ -69,18 +64,12 @@ export function DashboardStation(props: IDashboardStationProps) {
     }
   }, [isExecuteSuccess]);
 
-  function updatePluginState(command: string) {
-    if (isExecuteLoading) return;
-    const payload = { command } as PluginExecuteRequest;
-    mutateExecute({ payload });
-  }
-
   return (
     <div
       className="grid lg:grid-cols-10  grid-rows-3 gap-4 h-fit"
       data-testid="dashboard-station"
     >
-      <div className="col-start-1 col-span-2  row-span-3">
+      <div className="col-start-1 col-span-2 row-span-3">
         <MassaWallet
           key="wallet"
           state={walletState}

--- a/web/massastation/src/pages/Index/DashboardStation.tsx
+++ b/web/massastation/src/pages/Index/DashboardStation.tsx
@@ -7,8 +7,12 @@ import { MassaLabs } from './Dashboard/Massalabs';
 import { Explorer } from './Dashboard/Explorer';
 import { Purrfect } from './Dashboard/Purrfect';
 import { Dusa } from './Dashboard/Dusa';
-import { MASSA_WALLET } from '@/const';
+import { MASSA_WALLET, PLUGIN_UPDATE } from '@/const';
 import { MassaPluginModel } from '@/models';
+import { MassaWallet } from './Dashboard/MassaWallet';
+import { PluginExecuteRequest } from '../Store/StationSection/StationPlugin';
+import { usePost } from '@/custom/api';
+import { useEffect } from 'react';
 
 export interface IDashboardStationProps {
   massaPlugins?: MassaPluginModel[] | undefined;
@@ -27,13 +31,44 @@ export function DashboardStation(props: IDashboardStationProps) {
     massaPlugins,
   } = props;
 
+  const id = massaPlugins?.find(
+    (plugin: MassaPluginModel) => plugin.name === MASSA_WALLET,
+  )?.id;
+
+  const isUpdatable = massaPlugins?.find(
+    (plugin: MassaPluginModel) => plugin.name === MASSA_WALLET,
+  )?.updatable;
+
+  const {
+    mutate: mutateExecute,
+    isSuccess: isExecuteSuccess,
+    isLoading: isExecuteLoading,
+  } = usePost<PluginExecuteRequest>(`plugin-manager/${id}/execute`);
+
+  useEffect(() => {
+    if (isUpdatable) {
+      console.log('plugin is updatable');
+    } else {
+      console.log('plugin is not updatable');
+    }
+    if (isExecuteSuccess) {
+      console.log('plugin updated');
+    }
+  }, [isUpdatable, isExecuteLoading, isExecuteSuccess]);
+
+  function updatePluginState(command: string) {
+    if (isExecuteLoading) return;
+    const payload = { command } as PluginExecuteRequest;
+    mutateExecute({ payload });
+  }
+
   return (
     <div
-      className="grid lg:grid-cols-10  grid-rows-3 gap-4 h-fit p-4"
+      className="grid lg:grid-cols-10  grid-rows-3 gap-4 h-fit"
       data-testid="dashboard-station"
     >
       <div className="col-start-1 col-span-2  row-span-3">
-        <PluginWallet
+        <MassaWallet
           key="wallet"
           isActive={pluginWalletIsInstalled}
           status={
@@ -41,6 +76,7 @@ export function DashboardStation(props: IDashboardStationProps) {
               (plugin: MassaPluginModel) => plugin.name === MASSA_WALLET,
             )?.status
           }
+          isUpdatable={isUpdatable}
           isLoading={isLoading}
           title="Massa Wallet"
           iconActive={<WalletActive />}
@@ -54,6 +90,7 @@ export function DashboardStation(props: IDashboardStationProps) {
           onClickInactive={() =>
             urlPlugin ? handleInstallPlugin(urlPlugin) : null
           }
+          onUpdateClick={() => updatePluginState(PLUGIN_UPDATE)}
         />
       </div>
       <div className="col-start-3 col-span-2 row-start-1 row-span-2">

--- a/web/massastation/src/pages/Store/StationSection/StationPlugin.tsx
+++ b/web/massastation/src/pages/Store/StationSection/StationPlugin.tsx
@@ -158,6 +158,7 @@ export function StationPlugin({
             ) : (
               <Button
                 variant="icon"
+                hoverText={Intl.t('store.update')}
                 onClick={(e) => updatePluginState(e, PLUGIN_UPDATE)}
                 disabled={isExecuteLoading}
               >

--- a/web/massastation/src/pages/Store/StationSection/StationPlugin.tsx
+++ b/web/massastation/src/pages/Store/StationSection/StationPlugin.tsx
@@ -27,7 +27,7 @@ import Intl from '@/i18n/i18n';
 
 import { MassaPluginModel, PluginStatus } from '@/models';
 
-interface PluginExecuteRequest {
+export interface PluginExecuteRequest {
   command: string;
 }
 


### PR DESCRIPTION
Changes: 

Plugin Wallet is now a component hosted in station repo (not ui-kit)
Update Plugin logic is contained in a custom hook and called in two places: dashboard and plugin store 

These changes enables the user to directly update MW plugin in the dashboard ui without having to navigate to the plugin store 