### PR TITLE
refactor: drop legacy // +build comment

### DIFF
--- a/int/configuration/configuration_unix_test.go
+++ b/int/configuration/configuration_unix_test.go
@@ -1,5 +1,4 @@
 //go:build unix
-// +build unix
 
 package configuration
 

--- a/int/configuration/configuration_windows_test.go
+++ b/int/configuration/configuration_windows_test.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 package configuration
 

--- a/pkg/certstore/api_windows.go
+++ b/pkg/certstore/api_windows.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 package certstore
 

--- a/pkg/certstore/store_windows.go
+++ b/pkg/certstore/store_windows.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 // This package provides a collection of operations to manage system certificate stores on Windows.
 //

--- a/pkg/certstore/store_windows_test.go
+++ b/pkg/certstore/store_windows_test.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 package certstore
 

--- a/pkg/nss/runner_windows.go
+++ b/pkg/nss/runner_windows.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 package nss
 


### PR DESCRIPTION
## Delivery Quality Checklist

- [ ] **Breaking Changes in API:**
  Does this PR introduce breaking changes in the API?
    - If yes, have you considered making it backward compatible?
    - If backward compatibility is not considered, set the "breaking-change" label.

- [ ] **Changelog:**
  - [ ] For bugfix PR, set the "bugfix" label
  - [x] If this change should not appear in changelog, use "ignore-for-changelog" label

- [ ] **Version Update Handling:**
  Have you ensured that the version update by user is handled correctly?

- [ ] **PR Dependency:**
  Does this PR depend on another PR?
    - If yes, is it necessary for the dependency to be released prior to merging this one?

- [ ] **Documentation:**
  - [ ] Are any necessary changes made to user-facing documentation?
  - [ ] Confirm that API documentation is updated with any relevant changes.
  - [ ] Check that README and other documentation files are accurate and current.



From Go 1.17, the preferred syntax for build constraints is `//go:build`,
which replaces the old `// +build` form. The old style is now considered
deprecated but still supported for backward compatibility.

This change removes the obsolete `// +build xxx` line, keeping only the
modern `//go:build xxx` directive.

More info: https://github.com/golang/go/issues/41184 and https://go.dev/doc/go1.17#build-lines

Design Doc / Proposal：
https://go.dev/design/draft-gobuild
